### PR TITLE
feat: add options to copy summary as markdown or plain text

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -113,6 +113,11 @@ input::placeholder {
   overflow-y: auto;
 }
 
+#copy-btn-container {
+  display: flex;
+  gap: 15px;
+}
+
 #summary-result {
   font-size: 0.9rem;
   line-height: 1.6;

--- a/popup.html
+++ b/popup.html
@@ -37,7 +37,14 @@
         <div id="result-container" class="hidden">
           <h2>Summary</h2>
           <div id="summary-result"></div>
-          <button id="copy-btn" class="btn-secondary">Copy to Clipboard</button>
+          <div id="copy-btn-container">
+            <button id="copy-md-btn" class="btn-secondary">
+              Copy as Markdown
+            </button>
+            <button id="copy-plain-btn" class="btn-secondary">
+              Copy as Plain Text
+            </button>
+          </div>
         </div>
 
         <p id="error-msg" class="error hidden"></p>

--- a/popup.js
+++ b/popup.js
@@ -1,6 +1,7 @@
 document.addEventListener("DOMContentLoaded", init);
 
 const $ = (id) => document.getElementById(id);
+let summary = null;
 
 // ============================================================================
 // ERROR HANDLING SYSTEM
@@ -107,7 +108,8 @@ async function init() {
 
   $("save-key").addEventListener("click", saveApiKey);
   $("summarize-btn").addEventListener("click", summarizePage);
-  $("copy-btn").addEventListener("click", copyToClipboard);
+  $("copy-md-btn").addEventListener("click", copyAsMarkdown);
+  $("copy-plain-btn").addEventListener("click", copyAsPlainText);
 }
 
 async function saveApiKey() {
@@ -123,6 +125,7 @@ async function saveApiKey() {
 }
 
 async function summarizePage() {
+  summary = null;
   const stored = await chrome.storage.local.get(["openai_api_key"]);
   const apiKey = stored.openai_api_key;
 
@@ -171,7 +174,7 @@ async function summarizePage() {
       active: true,
       currentWindow: true,
     });
-    const summary = await generateSummary(
+    summary = await generateSummary(
       apiKey,
       pageContent,
       summaryType,
@@ -394,7 +397,23 @@ function hideError() {
   $("error-msg").classList.add("hidden");
 }
 
-async function copyToClipboard() {
+async function copyAsMarkdown() {
+  try {
+    const text = summary;
+    if (!text) {
+      showError("📋 No summary to copy.");
+      return;
+    }
+    await navigator.clipboard.writeText(text);
+    $("copy-md-btn").textContent = "Copied As Markdown!";
+    setTimeout(() => ($("copy-md-btn").textContent = "Copy As Markdown"), 2000);
+  } catch (err) {
+    console.error("[Clipboard Error]", err);
+    showError("📋 Failed to copy. Try manual copy instead.");
+  }
+}
+
+async function copyAsPlainText() {
   try {
     const text = $("summary-result")?.textContent;
     if (!text) {
@@ -402,8 +421,11 @@ async function copyToClipboard() {
       return;
     }
     await navigator.clipboard.writeText(text);
-    $("copy-btn").textContent = "Copied!";
-    setTimeout(() => ($("copy-btn").textContent = "Copy to Clipboard"), 2000);
+    $("copy-plain-btn").textContent = "Copied As Plain Text!";
+    setTimeout(
+      () => ($("copy-plain-btn").textContent = "Copy As Plain Text"),
+      2000,
+    );
   } catch (err) {
     console.error("[Clipboard Error]", err);
     showError("📋 Failed to copy. Try manual copy instead.");


### PR DESCRIPTION
# 🚀 Pull Request

Thank you for your contribution! Please fill out the information below before submitting your PR.


## 📌 What does this PR do?
This PR replaces the single copy button with two distinct copy options: **"Copy As Markdown"** and **"Copy As Plain Text"**. This gives users complete control over how they extract and use the AI-generated summaries. 

Specifically, it:
* Declares a global `summary` variable to cache the raw API response, allowing the exact Markdown syntax (headers, bullet points, bolding) to be copied without HTML interference.
* Uses `.textContent` directly from the `#summary-result` container to cleanly strip away all Markdown formatting and HTML tags for a pure string paste.
* Improves UI feedback by temporarily updating the button text to `"Copied As Markdown!"` or `"Copied As Plain Text!"` for 2 seconds upon a successful copy.

## 🔗 Related Issue
Fixes #13

## 🛠️ Type of Change
Please check the relevant option:
- [ ] Bug fix 🐞
- [x] New feature 🚀
- [x] UI/UX improvement 🎨
- [ ] Documentation update 📚
- [ ] Refactor ♻️
- [ ] Other

## ✅ Checklist
Please ensure all the following are completed:

- [x] My code follows the project’s coding standards
- [x] I have tested my changes locally
- [x] No API keys or secrets are committed
- [x] Existing functionality is not broken
- [x] I have added comments where necessary

## 🧪 Testing Details
1. Loaded the unpacked extension locally in Chrome.
2. Generated a summary of a test webpage.
3. Clicked **Copy As Markdown** and pasted it into a text editor. Verified that the raw Markdown syntax (e.g., `**`, `##`) remained completely intact.
4. Clicked **Copy As Plain Text** and pasted it. Verified that the text pasted cleanly as pure strings without any structural formatting characters or HTML tags.
5. Verified that the buttons display the correct temporary "Copied!" messages and revert back properly after exactly 2 seconds.

## 🖼️ Screenshots (if UI changes)
<img width="1366" height="768" alt="fix" src="https://github.com/user-attachments/assets/c7b5457e-2d87-4952-b4a0-55ebc6221e39" />


## 💬 Additional Notes
To make the "Copy As Markdown" feature work, I had to hoist the `summary` variable out of the `summarizePage` function scope and declare it globally (`let summary = null;`) at the top of `popup.js`. This allows the copy function to access the raw API string before it gets parsed by `marked.js` and sanitized by `DOMPurify`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate copy options for summaries: users can now copy content as Markdown format or as plain text, replacing the previous single copy button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->