### PR TITLE
feat: add clear summary button

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -102,7 +102,10 @@ input::placeholder {
 .btn-secondary:hover {
   background: rgba(108, 99, 255, 0.1);
 }
-
+#clear-summary-btn{
+  width: 100%;
+  margin-top: 15px;
+}
 #result-container {
   margin-top: 20px;
   padding: 16px;

--- a/popup.html
+++ b/popup.html
@@ -45,6 +45,9 @@
               Copy as Plain Text
             </button>
           </div>
+          <button id="clear-summary-btn" class="btn-secondary">
+            Clear Summary
+          </button>
         </div>
 
         <p id="error-msg" class="error hidden"></p>

--- a/popup.js
+++ b/popup.js
@@ -110,6 +110,7 @@ async function init() {
   $("summarize-btn").addEventListener("click", summarizePage);
   $("copy-md-btn").addEventListener("click", copyAsMarkdown);
   $("copy-plain-btn").addEventListener("click", copyAsPlainText);
+  $("clear-summary-btn").addEventListener("click", clearSummary);
 }
 
 async function saveApiKey() {
@@ -405,8 +406,8 @@ async function copyAsMarkdown() {
       return;
     }
     await navigator.clipboard.writeText(text);
-    $("copy-md-btn").textContent = "Copied As Markdown!";
-    setTimeout(() => ($("copy-md-btn").textContent = "Copy As Markdown"), 2000);
+    $("copy-md-btn").textContent = "Copied as Markdown!";
+    setTimeout(() => ($("copy-md-btn").textContent = "Copy as Markdown"), 2000);
   } catch (err) {
     console.error("[Clipboard Error]", err);
     showError("📋 Failed to copy. Try manual copy instead.");
@@ -421,13 +422,20 @@ async function copyAsPlainText() {
       return;
     }
     await navigator.clipboard.writeText(text);
-    $("copy-plain-btn").textContent = "Copied As Plain Text!";
+    $("copy-plain-btn").textContent = "Copied as Plain Text!";
     setTimeout(
-      () => ($("copy-plain-btn").textContent = "Copy As Plain Text"),
+      () => ($("copy-plain-btn").textContent = "Copy as Plain Text"),
       2000,
     );
   } catch (err) {
     console.error("[Clipboard Error]", err);
     showError("📋 Failed to copy. Try manual copy instead.");
   }
+}
+
+function clearSummary() {
+  summary = null;
+  $("summary-result").innerHTML = "";
+  $("result-container").classList.add("hidden");
+  hideError();
 }


### PR DESCRIPTION
# 🚀 Pull Request

Thank you for your contribution! Please fill out the information below before submitting your PR.

## 📌 What does this PR do?
This PR introduces a **"Clear Summary"** button to the extension interface. It allows users to quickly reset the UI and clear the cached AI response without needing to close and reopen the extension. 

Specifically, this PR:
* Adds a `clearSummary()` function that securely resets the global `summary` variable to `null` to prevent accidental copying of old data.
* Clears the `#summary-result` inner HTML and hides the `#result-container` to restore the extension to its default state.
* Includes CSS styling (`width: 100%; margin-top: 15px;`) to seamlessly integrate the new button below the copy options.
* Binds the new button to the initialization sequence.

## 🔗 Related Issue
Fixes #15

## 🛠️ Type of Change
Please check the relevant option:
- [ ] Bug fix 🐞
- [x] New feature 🚀
- [x] UI/UX improvement 🎨
- [ ] Documentation update 📚
- [ ] Refactor ♻️
- [ ] Other

## ✅ Checklist
Please ensure all the following are completed:

- [x] My code follows the project’s coding standards
- [x] I have tested my changes locally
- [x] No API keys or secrets are committed
- [x] Existing functionality is not broken
- [x] I have added comments where necessary
- [x] I have updated documentation if required

## 🧪 Testing Details
1. Loaded the unpacked extension locally in Chrome.
2. Clicked "Summarize This Page" to generate a summary and reveal the results container.
3. Clicked the new **Clear Summary** button.
4. Verified that the result container immediately hid itself.
5. Attempted to click "Copy as Markdown" via the console/temporarily exposing the button to verify that the system correctly threw the "No summary to copy" error (confirming the global variable was successfully reset to `null`).

## 🖼️ Screenshots (if UI changes)
<img width="1366" height="768" alt="Screenshot from 2026-02-20 00-16-11" src="https://github.com/user-attachments/assets/aee7b191-9d4d-4693-ac30-b7ae8890786f" />


## 💬 Additional Notes
The clear button was deliberately placed inside the `#result-container` so that it automatically hides itself along with the text when clicked, keeping the initial default UI perfectly clean!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Clear Summary button to quickly reset and remove the current summary from view
  * Improved copy-to-clipboard feedback with temporary success confirmations that automatically revert after 2 seconds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->