### PR TITLE
feat: Add Word Count & Reading Time Display

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -198,6 +198,36 @@ input::placeholder {
   border: 1px solid rgba(251, 191, 36, 0.3);
 }
 
+.content-stats,
+.summary-stats {
+  font-size: 0.8rem;
+  color: #a0a0a0;
+  margin-bottom: 12px;
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 6px;
+  display: flex;
+  gap: 16px;
+}
+
+.content-stats .stat-item,
+.summary-stats .stat-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.content-stats .stat-label,
+.summary-stats .stat-label {
+  color: #888;
+}
+
+.content-stats .stat-value,
+.summary-stats .stat-value {
+  color: #a8d8ff;
+  font-weight: 500;
+}
+
 .loader {
   width: 18px;
   height: 18px;

--- a/popup.html
+++ b/popup.html
@@ -54,6 +54,7 @@
       </div>
 
       <div id="image-indicator" class="image-indicator"></div>
+      <div id="content-stats" class="content-stats hidden"></div>
 
       <button id="summarize-btn" class="btn-primary">
         <span id="btn-text">Summarize This Page</span>
@@ -63,6 +64,7 @@
       <div id="result-container" class="hidden">
         <h2>Summary</h2>
         <div id="summary-result"></div>
+        <div id="summary-stats" class="summary-stats"></div>
         <div id="copy-btn-container">
           <button id="copy-md-btn" class="btn-secondary">
             Copy as Markdown

--- a/popup.js
+++ b/popup.js
@@ -4,6 +4,95 @@ const $ = (id) => document.getElementById(id);
 let summary = null;
 
 // ============================================================================
+// WORD COUNT & READING TIME UTILITIES
+// ============================================================================
+
+/**
+ * Count words in a text string
+ * @param {string} text - The text to count words in
+ * @returns {number} - Number of words
+ */
+function countWords(text) {
+  if (!text || typeof text !== 'string') return 0;
+  return text.trim().split(/\s+/).filter(word => word.length > 0).length;
+}
+
+/**
+ * Calculate estimated reading time based on word count
+ * Uses average reading speed of 200 words per minute
+ * @param {number} wordCount - Number of words
+ * @returns {string} - Formatted reading time string
+ */
+function calculateReadingTime(wordCount) {
+  const wordsPerMinute = 200;
+  const minutes = Math.ceil(wordCount / wordsPerMinute);
+  
+  if (minutes < 1) {
+    return '< 1 min';
+  } else if (minutes === 1) {
+    return '1 min';
+  } else {
+    return `${minutes} mins`;
+  }
+}
+
+/**
+ * Format word count with proper separator
+ * @param {number} count - Word count
+ * @returns {string} - Formatted word count string
+ */
+function formatWordCount(count) {
+  return count.toLocaleString();
+}
+
+/**
+ * Update content stats display (before summarization)
+ * @param {string} content - The extracted page content
+ */
+function updateContentStats(content) {
+  const contentStatsEl = $('content-stats');
+  if (!contentStatsEl) return;
+  
+  const wordCount = countWords(content);
+  const readingTime = calculateReadingTime(wordCount);
+  
+  contentStatsEl.innerHTML = `
+    <span class="stat-item">
+      <span class="stat-label">Words:</span>
+      <span class="stat-value">${formatWordCount(wordCount)}</span>
+    </span>
+    <span class="stat-item">
+      <span class="stat-label">Reading time:</span>
+      <span class="stat-value">${readingTime}</span>
+    </span>
+  `;
+  contentStatsEl.classList.remove('hidden');
+}
+
+/**
+ * Update summary stats display (after summarization)
+ * @param {string} summaryText - The generated summary
+ */
+function updateSummaryStats(summaryText) {
+  const summaryStatsEl = $('summary-stats');
+  if (!summaryStatsEl) return;
+  
+  const wordCount = countWords(summaryText);
+  const readingTime = calculateReadingTime(wordCount);
+  
+  summaryStatsEl.innerHTML = `
+    <span class="stat-item">
+      <span class="stat-label">Words:</span>
+      <span class="stat-value">${formatWordCount(wordCount)}</span>
+    </span>
+    <span class="stat-item">
+      <span class="stat-label">Reading time:</span>
+      <span class="stat-value">${readingTime}</span>
+    </span>
+  `;
+}
+
+// ============================================================================
 // ERROR HANDLING SYSTEM
 // ============================================================================
 
@@ -281,6 +370,9 @@ async function summarizePage() {
       pageContent = extractedContent.text;
       extractedImages = extractedContent.images || [];
 
+      // Display content word count and reading time
+      updateContentStats(pageContent);
+
       // Show image indicator
       const providerObj = {
         openai: window.OpenAIProvider,
@@ -335,6 +427,9 @@ async function summarizePage() {
     // Safely inject sanitized HTML into the UI
     $("summary-result").innerHTML = cleanHTML;
     $("result-container").classList.remove("hidden");
+
+    // Display summary word count and reading time
+    updateSummaryStats(summary);
 
     // Save to history
     saveSummary(summary, tab.title, tab.url, summaryType);
@@ -732,4 +827,3 @@ async function clearHistory() {
     renderHistory([]);
   }
 }
-


### PR DESCRIPTION
## Changes Made:
popup.html - Added display elements:

- <div id="content-stats" class="content-stats hidden"></div> - Shows content word count and reading time before summarization
- <div id="summary-stats" class="summary-stats"></div> - Shows summary word count and reading time after generation

popup.js - Added logic:

- countWords(text) - Counts words in a text string
- calculateReadingTime(wordCount) - Calculates estimated reading time (200 words per minute)
- formatWordCount(count) - Formats word count with proper separator
- updateContentStats(content) - Displays content word count and reading time before AI summarization
- updateSummaryStats(summaryText) - Displays summary word count and reading time after generation

popup.css - Added styling for:

- .content-stats and .summary-stats classes with proper font sizes, colors, and layout

## Expected Behavior:

- Show content word count and estimated reading time after page content is extracted, before sending to AI
- Show summary word count and estimated reading time after summary is generated
- Reading time is calculated at 200 words per minute (average reading speed)
- 

solves #20 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added word count statistics displayed for both extracted content and generated summaries
  * Added reading time estimates calculated and displayed before and after summarization
  * Enhanced UI with dedicated statistics panels to present content and summary metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->