### PR TITLE
Add keyboard shortcut to trigger summarization

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,6 +1,11 @@
 chrome.commands.onCommand.addListener(async (command) => {
   if (command === "summarize-page") {
     await chrome.storage.session.set({ autoSummarize: true });
-    chrome.action.openPopup();
+    try {
+      await chrome.action.openPopup();
+    } catch (error) {
+      await chrome.storage.session.remove("autoSummarize");
+      console.error("Failed to open extension popup for summarize-page command", error);
+    }
   }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,7 @@
   "background": {
     "service_worker": "background.js"
   },
+  "minimum_chrome_version": "127",
   "commands": {
     "summarize-page": {
       "suggested_key": {

--- a/popup.js
+++ b/popup.js
@@ -280,7 +280,7 @@ async function init() {
   const shortcutData = await chrome.storage.session.get(['autoSummarize']);
   if (shortcutData.autoSummarize) {
     await chrome.storage.session.remove(['autoSummarize']);
-    setTimeout(() => $("summarize-btn").click(), 100);
+    setTimeout(() => $("summarize-btn")?.click(), 100);
   }
 }
 


### PR DESCRIPTION
# 🚀 Pull Request

Thank you for your contribution! Please fill out the information below before submitting your PR.

## 📌 What does this PR do?

Adds keyboard shortcut support (Ctrl+Shift+S / Cmd+Shift+S) to quickly trigger page summarization without manually opening the extension popup and clicking the button.

## 🔗 Related Issue

Fixes #19 

## 🛠️ Type of Change

Please check the relevant option:

- [ ] Bug fix 🐞
- [x] New feature 🚀
- [ ] UI/UX improvement 🎨
- [ ] Documentation update 📚
- [ ] Refactor ♻️
- [ ] Other

## ✅ Checklist

Please ensure all the following are completed:

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
- [x] No API keys or secrets are committed
- [x] Existing functionality is not broken
- [x] I have added comments where necessary
- [x] I have updated documentation if required

## 🧪 Testing Details

Tested by loading the extension in Chrome and pressing Ctrl+Shift+S on various web pages. The popup opens automatically and the summarize button is triggered, generating summaries as expected. Verified that manual popup usage still works normally.


## 💬 Additional Notes

Implementation uses a minimal approach with a background service worker that sets a session flag when the keyboard shortcut is pressed. The popup detects this flag on load and auto-clicks the summarize button. All existing functionality remains unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a keyboard shortcut (Ctrl+Shift+S on Windows/Linux; Cmd+Shift+S on Mac) to summarize the current page.
  * Shortcut now triggers automatic one-time summarization when the extension popup opens.

* **Chores**
  * Updated extension to Manifest V3; now requires Chrome 127 or later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->